### PR TITLE
Up Junit to version 5 for unit tests

### DIFF
--- a/code/EventLinkQR/app/build.gradle.kts
+++ b/code/EventLinkQR/app/build.gradle.kts
@@ -6,6 +6,10 @@ android {
     namespace = "com.example.eventlinkqr"
     compileSdk = 34
 
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
+
     defaultConfig {
         applicationId = "com.example.eventlinkqr"
         minSdk = 24
@@ -33,7 +37,9 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:5.10.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/ExampleUnitTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/ExampleUnitTest.java
@@ -1,8 +1,9 @@
 package com.example.eventlinkqr;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Example local unit test, which will execute on the development machine (host).


### PR DESCRIPTION
Unless there is a good reason not to use JUnit 5, I figured we should just get this into main. Also added the mockito package for mocking things in unit tests