### PR TITLE
Add support for FirebaseFirestore in DatabaseManager

### DIFF
--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/DatabaseManager.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/DatabaseManager.java
@@ -1,6 +1,7 @@
 package com.example.eventlinkqr;
 
 import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.firestore.FirebaseFirestore;
 
 /**
  * Singleton class to manage the Firebase Realtime Database instance.
@@ -9,15 +10,22 @@ import com.google.firebase.database.FirebaseDatabase;
  * to the Firebase Realtime Database.
  */
 public class DatabaseManager {
-    private static DatabaseManager instance; // Singleton instance of DatabaseManager
-    private final FirebaseDatabase database; // Instance of FirebaseDatabase
+    /** Singleton instance of DatabaseManager */
+    private static volatile DatabaseManager instance;
+
+    /** Instance of FirebaseDatabase */
+    private final FirebaseDatabase firebaseDatabase;
+
+    /** Instance of Firestore database */
+    private final FirebaseFirestore firebaseFirestore;
 
     /**
      * Private constructor to prevent instantiation from outside the class.
      * Initializes the FirebaseDatabase instance.
      */
     private DatabaseManager() {
-        database = FirebaseDatabase.getInstance();
+        firebaseDatabase = FirebaseDatabase.getInstance();
+        firebaseFirestore = FirebaseFirestore.getInstance();
     }
 
     /**
@@ -43,7 +51,15 @@ public class DatabaseManager {
      *
      * @return The FirebaseDatabase instance for database operations.
      */
-    public FirebaseDatabase getDatabase() {
-        return database;
+    public FirebaseDatabase getFirebaseDatabase() {
+        return firebaseDatabase;
+    }
+
+    /**
+     * Provides access to the FirebaseFirestore instance.
+     * @return The FirebaseFirestore instance for database operations.
+     */
+    public FirebaseFirestore getFirebaseFirestore() {
+        return firebaseFirestore;
     }
 }

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/DatabaseManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/DatabaseManagerTest.java
@@ -1,25 +1,44 @@
 package com.example.eventlinkqr;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mockStatic;
 import com.google.firebase.database.FirebaseDatabase;
-import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import static org.mockito.Mockito.mock;
+import com.google.firebase.firestore.FirebaseFirestore;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+
+@ExtendWith(MockitoExtension.class)
 public class DatabaseManagerTest {
+
+    @Mock
+    public FirebaseDatabase mockFirebaseDatabase;
+
+    @Mock FirebaseFirestore mockFirebaseFirestore;
 
     @Test
     public void testDatabaseInitialization() {
-        try (MockedStatic<FirebaseDatabase> mocked = mockStatic(FirebaseDatabase.class)) {
-            FirebaseDatabase mockDatabase = mock(FirebaseDatabase.class);
-            mocked.when(FirebaseDatabase::getInstance).thenReturn(mockDatabase);
+        try (MockedStatic<FirebaseDatabase> mockedDatabase = mockStatic(FirebaseDatabase.class);
+                MockedStatic<FirebaseFirestore> mockedFirestore = mockStatic(FirebaseFirestore.class)) {
+            mockedDatabase.when(FirebaseDatabase::getInstance).thenReturn(mockFirebaseDatabase);
+            mockedFirestore.when(FirebaseFirestore::getInstance).thenReturn(mockFirebaseFirestore);
 
             DatabaseManager manager = DatabaseManager.getInstance();
-            FirebaseDatabase database = manager.getDatabase();
+            FirebaseDatabase database = manager.getFirebaseDatabase();
+            FirebaseFirestore firestore = manager.getFirebaseFirestore();
 
-            assertNotNull(database);
-            mocked.verify(FirebaseDatabase::getInstance);
+            assertEquals(database, mockFirebaseDatabase);
+            assertEquals(firestore, mockFirebaseFirestore);
+            mockedDatabase.verify(FirebaseDatabase::getInstance);
+            mockedFirestore.verify(FirebaseFirestore::getInstance);
         }
     }
 }


### PR DESCRIPTION
Since some of our app needs the realtime capabilities of FirebaseDatabase, while others need FirebaseFirestore, this allows us to use both. 