### PR TITLE
Improve QR Code for working with the database

### DIFF
--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/Event.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/Event.java
@@ -5,14 +5,12 @@ package com.example.eventlinkqr;
  */
 public class Event {
     /** All the attributes of an event*/
-    private QRCode qr;
     private String name, description, category, date, location;
     private String id;
     private Boolean geoTracking;
 
     /**
      * Event creator with all attributes
-     * @param qr the event's QR code
      * @param name the event's name
      * @param description the event's description
      * @param category the event's category
@@ -20,8 +18,7 @@ public class Event {
      * @param location the event's location
      * @param geoTracking whether the event has geolocation tracking or not
      */
-    public Event(QRCode qr, String name, String description, String category, String date, String location, Boolean geoTracking) {
-        this.qr = qr;
+    public Event(String name, String description, String category, String date, String location, Boolean geoTracking) {
         this.name = name;
         this.description = description;
         this.category = category;
@@ -38,14 +35,6 @@ public class Event {
     public Event(String name, String description) {
         this.name = name;
         this.description = description;
-    }
-
-    /**
-     * gets the event's QR code
-     * @return the event's QR code
-     */
-    public QRCode getQr() {
-        return qr;
     }
 
     /**

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
@@ -89,7 +89,6 @@ public class EventManager extends Manager {
      */
     private static Event fromDocument(DocumentSnapshot document) {
         Event e =  new Event(
-                new QRCode("Test"),
                 document.get("name", String.class),
                 document.get("description", String.class),
                 document.get("category", String.class),

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/QRCode.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/QRCode.java
@@ -4,15 +4,27 @@ import android.graphics.Bitmap;
 
 /** Representation of a QR Code that is used in the app. */
 public class QRCode {
+    public static final int CHECK_IN_TYPE = 1;
+    public static final int PROMOTIONAL_TYPE = 2;
+
+
     /** The text encoded in the QR Code */
-    private final String codeText;
+    private String codeText;
+
+    private int codeType;
+
+    private String eventId;
 
     /**
-     * Create a new QRCode from text
-     * @param codeText The text to be encoded.
+     * Create a QR Code object from data that can be retrieved from the firestore.
+     * @param codeText Text encoded in the QR Code
+     * @param codeType Type of the QR Code (Check in, Promotional)
+     * @param eventId Id of the event that this code is associated with.
      */
-    public QRCode(String codeText) {
+    public QRCode(String codeText, int codeType, String eventId) {
         this.codeText = codeText;
+        this.codeType = codeType;
+        this.eventId = eventId;
     }
 
     /**
@@ -21,6 +33,46 @@ public class QRCode {
      */
     public String getCodeText() {
         return codeText;
+    }
+
+    /**
+     * Set the text encoded in the QR Code
+     * @param codeText Encoded text
+     */
+    public void setCodeText(String codeText) {
+        this.codeText = codeText;
+    }
+
+    /**
+     * Get the type of the code
+     * @return Either CHECK_IN_TYPE or PROMOTIONAL_TYPE
+     */
+    public int getCodeType() {
+        return codeType;
+    }
+
+    /**
+     * Set the type of the code
+     * @param codeType Either CHECK_IN_TYPE or PROMOTIONAL_TYPE
+     */
+    public void setCodeType(int codeType) {
+        this.codeType = codeType;
+    }
+
+    /**
+     * Get the id of the event that this code belongs to
+     * @return The event id
+     */
+    public String getEventId() {
+        return eventId;
+    }
+
+    /**
+     * Set the id for the event that this belongs to
+     * @param event The event id
+     */
+    public void setEventId(String event) {
+        this.eventId = event;
     }
 
     /**

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/QRCodeManager.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/QRCodeManager.java
@@ -1,0 +1,45 @@
+package com.example.eventlinkqr;
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Class for managing QR Codes interaction with the database */
+public class QRCodeManager extends Manager {
+    private static final String COLLECTION_PATH = "QRCode";
+
+    /**
+     * Add a QR code to the QRCode collection
+     * @param codeText The text encoded in the QR Code
+     * @param codeType The type of QRCode
+     * @param event The event that the code belongs to
+     * @return Task to listen for success / failure
+     */
+    public static Task<Void> addQRCode(String codeText, int codeType, Event event) {
+        Map<String, Object> qrCode = new HashMap<>();
+        qrCode.put("codeType", codeType);
+        qrCode.put("event", "/Event/" + event.getId());
+        return getCollection().document(codeText).set(qrCode);
+    }
+
+    /**
+     * Get a QRCode object based on the encoded text
+     * @param barcodeText The text from a scanned code
+     * @return A task with the QRCode object
+     */
+    public static Task<QRCode> fetchQRCode(String barcodeText) {
+        return getCollection().document(barcodeText).get().continueWith(d -> {
+            DocumentSnapshot doc = d.getResult();
+            String eventId = doc.get("event", DocumentReference.class).getId();
+            return new QRCode(barcodeText, doc.get("codeType", Integer.class), eventId);
+        });
+    }
+
+    private static CollectionReference getCollection() {
+        return getFirebase().collection(COLLECTION_PATH);
+    }
+}

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/QRCodeScanner.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/QRCodeScanner.java
@@ -33,7 +33,7 @@ public class QRCodeScanner {
      * @param successCallback Callback to be invoked when a QR code is successfully scanned.
      * @param failureCallback Callback to be invoked when an error occurs during scan.
      */
-    public void codeFromScan(Consumer<QRCode> successCallback, Consumer<Exception> failureCallback) {
+    public void codeFromScan(Consumer<String> successCallback, Consumer<Exception> failureCallback) {
         scanner.startScan()
                 .addOnSuccessListener(barcode -> {
                     String barcodeText = barcode.getRawValue();
@@ -43,8 +43,7 @@ public class QRCodeScanner {
                         barcodeText = hashBarcodeText(barcodeText);
                     }
 
-                    QRCode code = new QRCode(barcodeText);
-                    successCallback.accept(code);
+                    successCallback.accept(barcodeText);
                 })
                 .addOnFailureListener(failureCallback::accept);
     }

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeGeneratorTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeGeneratorTest.java
@@ -22,7 +22,7 @@ public class QRCodeGeneratorTest {
 
     @BeforeEach
     public void setup() {
-        code = new QRCode("test");
+        code = new QRCode("test", QRCode.CHECK_IN_TYPE, "event");
     }
 
     @Test

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeScannerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeScannerTest.java
@@ -32,7 +32,7 @@ public class QRCodeScannerTest {
     @Mock
     private GmsBarcodeScanner mockScanner;
     @Mock
-    private Consumer<QRCode> mockSuccessConsumer;
+    private Consumer<String> mockSuccessConsumer;
     @Mock
     private Consumer<Exception> mockFailuerConsumer;
     @Mock

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeTest.java
@@ -25,7 +25,7 @@ public class QRCodeTest {
 
     @BeforeEach
     public void setup() {
-        code = new QRCode(TEST_CODE_TEXT);
+        code = new QRCode(TEST_CODE_TEXT, QRCode.CHECK_IN_TYPE, "event");
     }
 
     @Test
@@ -45,7 +45,7 @@ public class QRCodeTest {
 
     @Test
     public void testToBitmapThrows() {
-        QRCode emptyCode = new QRCode("");
+        QRCode emptyCode = new QRCode("", QRCode.CHECK_IN_TYPE, "event");
 
         try (MockedStatic<QRCodeGenerator> mockedQRCodeGen = mockStatic(QRCodeGenerator.class)) {
             mockedQRCodeGen.when(() -> QRCodeGenerator.imageFromQRCode(eq(emptyCode), eq(WIDTH), eq(HEIGHT)))


### PR DESCRIPTION
@adrienz1 I am open to suggestion here, and in fact feel free to check out this branch and make necessary changes.

Overall, this change means the `QRCode` class is only really used to represent the object that we have in the firestore. Scanning now just returns the `codeText` which *can* be used to fetch a `QRCode` for say check in purposes.

The `QRCodeManager` has a `addQRCode` method that you can use when creating the QR Codes for events.