### PR TITLE
Implement check-in scan, custom QR upload, and displaying event QR Code

### DIFF
--- a/code/EventLinkQR/app/build.gradle.kts
+++ b/code/EventLinkQR/app/build.gradle.kts
@@ -71,8 +71,8 @@ dependencies {
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     testImplementation("junit:junit:4.12")
     testImplementation ("org.robolectric:robolectric:3.4.2")
-    testImplementation ("org.powermock:powermock-api-mockito2:2.0.9")
-    testImplementation ("org.powermock:powermock-module-junit4:2.0.9")
+    testImplementation("org.mockito:mockito-core:5.10.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
 
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/code/EventLinkQR/app/src/androidTest/java/com/example/eventlinkqr/AttendeeMainActivityTest.java
+++ b/code/EventLinkQR/app/src/androidTest/java/com/example/eventlinkqr/AttendeeMainActivityTest.java
@@ -1,0 +1,25 @@
+package com.example.eventlinkqr;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class AttendeeMainActivityTest {
+    @Test
+    public void openCamera() {
+        try (ActivityScenario<AttendeeMainActivity> activityScenario = ActivityScenario.launch(AttendeeMainActivity.class)) {
+            onView(withId(R.id.attendee_scan_button)).perform(click());
+
+            // Need to evaluate if this test is possible (it involves the Google QR Code scanner)
+        }
+    }
+}

--- a/code/EventLinkQR/app/src/main/AndroidManifest.xml
+++ b/code/EventLinkQR/app/src/main/AndroidManifest.xml
@@ -36,11 +36,6 @@
         <activity
             android:name=".UploadImageActivity"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
 
         <activity android:name=".LandingPage"/>

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/Event.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/Event.java
@@ -1,11 +1,14 @@
 package com.example.eventlinkqr;
 
+import com.google.firebase.Timestamp;
+
 /**
  * This class contains all necessary data for an event instance
  */
 public class Event {
     /** All the attributes of an event*/
-    private String name, description, category, date, location;
+    private String name, description, category, location;
+    private Timestamp date;
     private String id;
     private Boolean geoTracking;
 
@@ -18,7 +21,7 @@ public class Event {
      * @param location the event's location
      * @param geoTracking whether the event has geolocation tracking or not
      */
-    public Event(String name, String description, String category, String date, String location, Boolean geoTracking) {
+    public Event(String name, String description, String category, Timestamp date, String location, Boolean geoTracking) {
         this.name = name;
         this.description = description;
         this.category = category;
@@ -65,7 +68,7 @@ public class Event {
      * gets the event's date
      * @return the event's date
      */
-    public String getDate() {
+    public Timestamp getDate() {
         return date;
     }
 

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
@@ -22,13 +22,16 @@ import java.util.stream.Collectors;
 
 /** Class for managing database interaction for events */
 public class EventManager extends Manager {
-    /** The Firestore collection path for events */
+    /**
+     * The Firestore collection path for events
+     */
     private static final String COLLECTION_PATH = "Events";
 
     /**
      * Check the given attendee into an event
+     *
      * @param attendeeName The name of the attendee to check in
-     * @param eventId The id of the event to check into
+     * @param eventId      The id of the event to check into
      */
     public static Task<Void> checkIn(String attendeeName, String eventId) {
         Map<String, Object> attendee = new HashMap<>();
@@ -38,7 +41,8 @@ public class EventManager extends Manager {
 
     /**
      * Add a callback to changes in the Events
-     * @param organizer The organizer to filter events on
+     *
+     * @param organizer     The organizer to filter events on
      * @param eventCallback The callback to be invoked when the events change
      */
     public static void addEventSnapshotCallback(String organizer, Consumer<List<Event>> eventCallback) {
@@ -56,7 +60,8 @@ public class EventManager extends Manager {
 
     /**
      * Add a callback to changes in the event attendees.
-     * @param eventName Event to get attendees for
+     *
+     * @param eventName        Event to get attendees for
      * @param attendeeCallback The callback to be invoked when the event attendees change
      */
     public static void addEventAttendeeSnapshotCallback(String eventName, Consumer<List<String>> attendeeCallback) {
@@ -74,8 +79,9 @@ public class EventManager extends Manager {
 
     /**
      * Add a callback to changes in the event attendees.
-     * @param eventName Event to get attendees for
-     * @param checkedIn Filter on checked-in / not-checked-in attendees
+     *
+     * @param eventName        Event to get attendees for
+     * @param checkedIn        Filter on checked-in / not-checked-in attendees
      * @param attendeeCallback The callback to be invoked when the event attendees change
      */
     public static void addEventAttendeeSnapshotCallback(String eventName, boolean checkedIn, Consumer<List<String>> attendeeCallback) {
@@ -93,11 +99,12 @@ public class EventManager extends Manager {
 
     /**
      * Create an event from the document
+     *
      * @param document The document to generate the event from
      * @return The event
      */
     private static Event fromDocument(DocumentSnapshot document) {
-        Event e =  new Event(
+        Event e = new Event(
                 document.get("name", String.class),
                 document.get("description", String.class),
                 document.get("category", String.class),
@@ -110,6 +117,7 @@ public class EventManager extends Manager {
 
     /**
      * Get the events collection from firebase
+     *
      * @return The collection
      */
     private static CollectionReference getCollection() {
@@ -118,9 +126,12 @@ public class EventManager extends Manager {
 
     /**
      * Adds a new event to the database
-     * @param newEvent the new event to be added to the database
+     *
+     * @param newEvent  the new event to be added to the database
+     * @param organizer the organizer of the event
+     * @param customQR  (optional) encoded text for the qr code
      */
-    public static void createEvent(Event newEvent, String organizer){
+    public static void createEvent(Event newEvent, String organizer, String customQR) {
         HashMap<String, Object> newEventData = new HashMap<>();
         newEventData.put("name", newEvent.getName());
         newEventData.put("description", newEvent.getDescription());
@@ -134,14 +145,28 @@ public class EventManager extends Manager {
         newEventData.put("organizer", organizer);
 
         getCollection().add(newEventData)
-            .addOnSuccessListener(documentReference -> {
+                .addOnSuccessListener(documentReference -> {
                     String eventId = documentReference.getId();
+                    String codeText = customQR;
+                    if (codeText == null) {
+                        codeText = "eventlinkqr:" + eventId;
+                    }
                     // Automatically generate a QR Code for now. In the future support uploading custom.
-                    QRCodeManager.addQRCode("eventlinkqr:" + eventId, QRCode.CHECK_IN_TYPE, eventId);
-                    Log.e("Firestore", "Event " + newEvent.getName() +" by "+ organizer +" successfully added");
-            })
-            .addOnFailureListener(e -> {
-                Log.e("Firestore", "Event failed to be added");
-            });
+                    QRCodeManager.addQRCode(codeText, QRCode.CHECK_IN_TYPE, eventId);
+                    Log.e("Firestore", "Event " + newEvent.getName() + " by " + organizer + " successfully added");
+                })
+                .addOnFailureListener(e -> {
+                    Log.e("Firestore", "Event failed to be added");
+                });
+    }
+
+    /**
+     * Adds a new event to the database
+     *
+     * @param newEvent  the new event to be added to the database
+     * @param organizer the organizer of the event
+     */
+    public static void createEvent(Event newEvent, String organizer) {
+        EventManager.createEvent(newEvent, organizer, null);
     }
 }

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
@@ -33,10 +33,11 @@ public class EventManager extends Manager {
      * @param attendeeName The name of the attendee to check in
      * @param eventId      The id of the event to check into
      */
-    public static Task<Void> checkIn(String attendeeName, String eventId) {
+    public static Task<Void> checkIn(String uuid, String attendeeName, String eventId) {
         Map<String, Object> attendee = new HashMap<>();
+        attendee.put("name", attendeeName);
         attendee.put("checkedIn", true);
-        return getCollection().document(eventId).collection("attendees").document(attendeeName).set(attendee);
+        return getCollection().document(eventId).collection("attendees").document(uuid).set(attendee);
     }
 
     /**

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
@@ -70,7 +70,7 @@ public class EventManager extends Manager {
      * @param attendeeCallback The callback to be invoked when the event attendees change
      */
     public static void addEventAttendeeSnapshotCallback(String eventName, boolean checkedIn, Consumer<List<String>> attendeeCallback) {
-        getCollection().document(eventName).collection("Attendees").where(Filter.arrayContains("checkedIn", checkedIn)).addSnapshotListener((querySnapshots, error) -> {
+        getCollection().document(eventName).collection("attendees").where(Filter.arrayContains("checkedIn", checkedIn)).addSnapshotListener((querySnapshots, error) -> {
             if (error != null) {
                 Log.e("Firestore", error.toString());
                 return;
@@ -87,7 +87,7 @@ public class EventManager extends Manager {
      * @param document The document to generate the event from
      * @return The event
      */
-    public static Event fromDocument(DocumentSnapshot document) {
+    private static Event fromDocument(DocumentSnapshot document) {
         Event e =  new Event(
                 document.get("name", String.class),
                 document.get("description", String.class),

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/EventManager.java
@@ -23,8 +23,8 @@ public class EventManager extends Manager {
      * @param attendeeName The name of the attendee to check in
      * @param eventId The id of the event to check into
      */
-    public static void checkIn(String attendeeName, String eventId) {
-        getCollection().document(eventId).collection("attendees").document(attendeeName).update("checkedIn", true);
+    public static Task<Void> checkIn(String attendeeName, String eventId) {
+        return getCollection().document(eventId).collection("attendees").document(attendeeName).update("checkedIn", true);
     }
 
     /**
@@ -87,12 +87,12 @@ public class EventManager extends Manager {
      * @param document The document to generate the event from
      * @return The event
      */
-    private static Event fromDocument(DocumentSnapshot document) {
+    public static Event fromDocument(DocumentSnapshot document) {
         Event e =  new Event(
                 document.get("name", String.class),
                 document.get("description", String.class),
                 document.get("category", String.class),
-                document.get("dateAndTime", Timestamp.class).toString(),
+                document.get("dateAndTime", Timestamp.class),
                 document.get("location", String.class),
                 document.get("geoTracking", Boolean.class));
         e.setId(document.getId());

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/MainActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/MainActivity.java
@@ -8,23 +8,21 @@ import android.view.View;
 import android.widget.Button;
 
 public class MainActivity extends AppCompatActivity {
-    private Button orgButton, adminButton, attendeeButton;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        orgButton = findViewById(R.id.button3);
-        attendeeButton = findViewById(R.id.button4);
-        adminButton = findViewById(R.id.button5);
+        Button orgButton = findViewById(R.id.button3);
+        Button attendeeButton = findViewById(R.id.button4);
+        Button adminButton = findViewById(R.id.button5);
 
-        orgButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
+        orgButton.setOnClickListener(v -> {
                 startActivity(new Intent(MainActivity.this, OrgMainActivity.class));
-            }
+        });
+
+        attendeeButton.setOnClickListener(v -> {
+            startActivity(new Intent(MainActivity.this, AttendeeMainActivity.class));
         });
     }
-
-//    Added comment
 }

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/OrgCreateEventFragment.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/OrgCreateEventFragment.java
@@ -25,6 +25,8 @@ import com.google.firebase.Timestamp;
  */
 public class OrgCreateEventFragment extends Fragment {
 
+    private String customQRString;
+
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
@@ -87,7 +89,7 @@ public class OrgCreateEventFragment extends Fragment {
                 Event newEvent = new Event(name, description, category, Timestamp.now(), location, tracking);
                 String organizer = ((OrgMainActivity) requireActivity()).getOrganizerName();
 
-                EventManager.createEvent(newEvent, organizer);
+                EventManager.createEvent(newEvent, organizer, customQRString);
 
                 // return to the home page
                 Navigation.findNavController(view).navigate(R.id.action_createEventFragment_to_org_home_page);
@@ -96,8 +98,16 @@ public class OrgCreateEventFragment extends Fragment {
         });
 
         // send message since the function is not yet implemented
-        chooseQrButton.setOnClickListener(v ->
-                Toast.makeText(getContext(), "This function is not ready yet", Toast.LENGTH_SHORT).show());
+        chooseQrButton.setOnClickListener(v -> {
+            publishButton.setEnabled(false);
+            ((OrgMainActivity) requireActivity()).getScanner().codeFromScan(codeText -> {
+                this.customQRString = codeText;
+                publishButton.setEnabled(true);
+            }, e -> {
+                Toast.makeText(requireActivity(), "Code scan failed", Toast.LENGTH_SHORT).show();
+                publishButton.setEnabled(true);
+            });
+        });
 
     }
 

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/OrgCreateEventFragment.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/OrgCreateEventFragment.java
@@ -82,9 +82,9 @@ public class OrgCreateEventFragment extends Fragment {
             if(name.equals("") || description.equals("") || location.equals("") || category.equals("Category")){
                 // send wrong password message
                 Toast.makeText(getContext(), "Please fill all fields", Toast.LENGTH_SHORT).show();
-            }else{
+            } else {
                 // create new event form data and add it toi the database using the event manager
-                Event newEvent = new Event(name, description, category, Timestamp.now().toDate().toString(), location, tracking);
+                Event newEvent = new Event(name, description, category, Timestamp.now(), location, tracking);
                 String organizer = ((OrgMainActivity) requireActivity()).getOrganizerName();
 
                 EventManager.createEvent(newEvent, organizer);

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/OrgEventFragment.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/OrgEventFragment.java
@@ -5,6 +5,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -24,6 +25,8 @@ public class OrgEventFragment extends Fragment {
     private Toolbar orgEventToolBar;
     private TextView eventTitle, eventLocation, eventDescription;
 
+    private ImageView qrCodeImage;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -38,6 +41,7 @@ public class OrgEventFragment extends Fragment {
         eventTitle = view.findViewById(R.id.org_event_name);
         eventLocation= view.findViewById(R.id.org_event_location);
         eventDescription= view.findViewById(R.id.org_event_description);
+        qrCodeImage = view.findViewById(R.id.imageView);
 
         orgEventToolBar = view.findViewById(R.id.org_event_toolbar);
         ((AppCompatActivity) requireActivity()).setSupportActionBar(orgEventToolBar);
@@ -61,6 +65,14 @@ public class OrgEventFragment extends Fragment {
         eventTitle.setText(event.getName());
         eventLocation.setText(event.getLocation());
         eventDescription.setText(event.getDescription());
+
+        QRCodeManager.fetchQRCode(event, QRCode.CHECK_IN_TYPE).addOnSuccessListener(q -> {
+            try {
+                qrCodeImage.setImageBitmap(q.toBitmap(512, 512));
+            } catch (QRCodeGeneratorException e) {
+                throw new RuntimeException(e);
+            }
+        });
 
         // Inflate the layout for this fragment
         return view;

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/OrgMainActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/OrgMainActivity.java
@@ -17,13 +17,15 @@ public class OrgMainActivity extends AppCompatActivity {
     private FragmentContainerView navController;
     private Event currentEvent;
     private String organizerName;
+
+    private QRCodeScanner scanner;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.org_main);
         homeButton = findViewById(R.id.org_home_button);
         navController = findViewById(R.id.org_nav_controller);
-
+        scanner = new QRCodeScanner(this);
         homeButton.setOnClickListener(v -> {
             Navigation.findNavController(navController).navigate(R.id.org_home_page);
         });
@@ -68,5 +70,13 @@ public class OrgMainActivity extends AppCompatActivity {
      */
     public void setButtonsVisible(){
         findViewById(R.id.org_main_buttons).setVisibility(View.VISIBLE);
+    }
+
+    /**
+     * Get the qrCode scanner
+     * @return The QRCode scanner
+     */
+    public QRCodeScanner getScanner() {
+        return scanner;
     }
 }

--- a/code/EventLinkQR/app/src/main/res/values/strings.xml
+++ b/code/EventLinkQR/app/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="channel_description">this is a notification channel\n</string>
     <string name="what_to_expect">What to expect</string>
     <string name="save_publish_string">Save and Publish</string>
-    <string name="choose_make_qr_string">Make/choose QR Code</string>
+    <string name="choose_make_qr_string">Scan Custom Code</string>
     <string name="prompt">Upload your image here</string>
     <string name="upload">Upload</string>
     <string name="cancel">Cancel</string>

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/EventManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/EventManagerTest.java
@@ -50,9 +50,9 @@ public class EventManagerTest {
             when(mockCollectionReference.document("eventId")).thenReturn(mockDocumentReference);
 
             when(mockDocumentReference.collection("attendees")).thenReturn(mockCollectionReference);
-            when(mockCollectionReference.document("David")).thenReturn(mockDocumentReference);
+            when(mockCollectionReference.document("875779a8-9646-40ce-b245-882ebdb707ee")).thenReturn(mockDocumentReference);
 
-            when(mockDocumentReference.update(eq("checkedIn"), eq(true))).thenReturn(Tasks.forResult(null));
+            when(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null));
 
             Task<Void> result = EventManager.checkIn("875779a8-9646-40ce-b245-882ebdb707ee", "David", "eventId");
 
@@ -67,9 +67,9 @@ public class EventManagerTest {
             when(mockCollectionReference.document("eventId")).thenReturn(mockDocumentReference);
 
             when(mockDocumentReference.collection("attendees")).thenReturn(mockCollectionReference);
-            when(mockCollectionReference.document("David")).thenReturn(mockDocumentReference);
+            when(mockCollectionReference.document("875779a8-9646-40ce-b245-882ebdb707ee")).thenReturn(mockDocumentReference);
 
-            when(mockDocumentReference.update(eq("checkedIn"), eq(true))).thenReturn(Tasks.forException(new Exception()));
+            when(mockDocumentReference.set(any())).thenReturn(Tasks.forException(new Exception()));
 
             Task<Void> result = EventManager.checkIn("875779a8-9646-40ce-b245-882ebdb707ee", "David", "eventId");
 

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/EventManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/EventManagerTest.java
@@ -106,7 +106,7 @@ public class EventManagerTest {
             when(mockCollectionReference.document(eq("eventName"))).thenReturn(mockDocumentReference);
             when(mockDocumentReference.collection(eq("attendees"))).thenReturn(mockCollectionReference);
             Query mockQuery = mock(Query.class);
-            when(mockCollectionReference.where(any())).thenReturn(mockQuery);
+            when(mockCollectionReference.whereEqualTo(eq("checkedIn"), any())).thenReturn(mockQuery);
             EventManager.addEventAttendeeSnapshotCallback("eventName", true, e -> {});
             verify(mockQuery, times(1)).addSnapshotListener(any());
         }

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/EventManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/EventManagerTest.java
@@ -1,0 +1,114 @@
+package com.example.eventlinkqr;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EventManagerTest {
+    @Mock
+    public CollectionReference mockCollectionReference;
+
+    @Mock
+    public DocumentReference mockDocumentReference;
+
+    @Mock
+    public DatabaseManager mockDb;
+
+    @Mock
+    public FirebaseFirestore mockFirestore;
+
+    @BeforeEach
+    void setUp() {
+        when(mockDb.getFirebaseFirestore()).thenReturn(mockFirestore);
+        when(mockFirestore.collection("Events")).thenReturn(mockCollectionReference);
+    }
+
+    @Test
+    public void testCheckIn() {
+        try (MockedStatic<DatabaseManager> mockedDbManager = mockStatic(DatabaseManager.class)) {
+            mockedDbManager.when(DatabaseManager::getInstance).thenReturn(mockDb);
+            when(mockCollectionReference.document("eventId")).thenReturn(mockDocumentReference);
+
+            when(mockDocumentReference.collection("attendees")).thenReturn(mockCollectionReference);
+            when(mockCollectionReference.document("David")).thenReturn(mockDocumentReference);
+
+            when(mockDocumentReference.update(eq("checkedIn"), eq(true))).thenReturn(Tasks.forResult(null));
+
+            Task<Void> result = EventManager.checkIn("David", "eventId");
+
+            Assertions.assertTrue(result.isSuccessful());
+        }
+    }
+
+    @Test
+    public void testCheckInFailed() {
+        try (MockedStatic<DatabaseManager> mockedDbManager = mockStatic(DatabaseManager.class)) {
+            mockedDbManager.when(DatabaseManager::getInstance).thenReturn(mockDb);
+            when(mockCollectionReference.document("eventId")).thenReturn(mockDocumentReference);
+
+            when(mockDocumentReference.collection("attendees")).thenReturn(mockCollectionReference);
+            when(mockCollectionReference.document("David")).thenReturn(mockDocumentReference);
+
+            when(mockDocumentReference.update(eq("checkedIn"), eq(true))).thenReturn(Tasks.forException(new Exception()));
+
+            Task<Void> result = EventManager.checkIn("David", "eventId");
+
+            Assertions.assertFalse(result.isSuccessful());
+        }
+    }
+
+    @Test
+    public void testAddEventSnapshotCallback() {
+        try (MockedStatic<DatabaseManager> mockedDbManager = mockStatic(DatabaseManager.class)) {
+            mockedDbManager.when(DatabaseManager::getInstance).thenReturn(mockDb);
+            Query mockQuery = mock(Query.class);
+            when(mockCollectionReference.whereEqualTo(eq("organizer"), eq("Me"))).thenReturn(mockQuery);
+            EventManager.addEventSnapshotCallback("Me", e -> {});
+            verify(mockQuery, times(1)).addSnapshotListener(any());
+        }
+    }
+
+    @Test
+    public void testAddEventAttendeeSnapshotCallback() {
+        try (MockedStatic<DatabaseManager> mockedDbManager = mockStatic(DatabaseManager.class)) {
+            mockedDbManager.when(DatabaseManager::getInstance).thenReturn(mockDb);
+            when(mockCollectionReference.document(eq("eventName"))).thenReturn(mockDocumentReference);
+            when(mockDocumentReference.collection(eq("attendees"))).thenReturn(mockCollectionReference);
+            EventManager.addEventAttendeeSnapshotCallback("eventName", e -> {});
+            verify(mockCollectionReference, times(1)).addSnapshotListener(any());
+        }
+    }
+
+    @Test
+    public void testAddEventAttendeeSnapshotCallbackWithFilter() {
+        try (MockedStatic<DatabaseManager> mockedDbManager = mockStatic(DatabaseManager.class)) {
+            mockedDbManager.when(DatabaseManager::getInstance).thenReturn(mockDb);
+            when(mockCollectionReference.document(eq("eventName"))).thenReturn(mockDocumentReference);
+            when(mockDocumentReference.collection(eq("attendees"))).thenReturn(mockCollectionReference);
+            Query mockQuery = mock(Query.class);
+            when(mockCollectionReference.where(any())).thenReturn(mockQuery);
+            EventManager.addEventAttendeeSnapshotCallback("eventName", true, e -> {});
+            verify(mockQuery, times(1)).addSnapshotListener(any());
+        }
+    }
+}

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/EventManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/EventManagerTest.java
@@ -54,7 +54,7 @@ public class EventManagerTest {
 
             when(mockDocumentReference.update(eq("checkedIn"), eq(true))).thenReturn(Tasks.forResult(null));
 
-            Task<Void> result = EventManager.checkIn("David", "eventId");
+            Task<Void> result = EventManager.checkIn("875779a8-9646-40ce-b245-882ebdb707ee", "David", "eventId");
 
             Assertions.assertTrue(result.isSuccessful());
         }
@@ -71,7 +71,7 @@ public class EventManagerTest {
 
             when(mockDocumentReference.update(eq("checkedIn"), eq(true))).thenReturn(Tasks.forException(new Exception()));
 
-            Task<Void> result = EventManager.checkIn("David", "eventId");
+            Task<Void> result = EventManager.checkIn("875779a8-9646-40ce-b245-882ebdb707ee", "David", "eventId");
 
             Assertions.assertFalse(result.isSuccessful());
         }

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/ImageManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/ImageManagerTest.java
@@ -1,20 +1,16 @@
 package com.example.eventlinkqr;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.net.Uri;
 
-import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -22,20 +18,13 @@ import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
 
-import org.junit.Before;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.robolectric.RobolectricTestRunner;
-
-import java.util.Arrays;
 
 @ExtendWith(MockitoExtension.class)
 @RunWith(RobolectricTestRunner.class)
@@ -49,96 +38,37 @@ public class ImageManagerTest {
     @Mock
     private StorageReference mockStorageRef;
     @Mock
+    private StorageReference mockImageRef;
+    @Mock
     private UploadTask mockUploadTask;
     @Mock
     private DocumentReference mockDocumentRef;
     @Mock
-    private Context context;
-    private ImageManager imageManager;
+    private Context mockContext;
 
-//    FirebaseStorage mockStorage = mock(FirebaseStorage.class);
-//    FirebaseFirestore mockDb = mock(FirebaseFirestore.class);
-
-
-//    @RunWith(PowerMockRunner.class)
-    @PrepareForTest({ FirebaseFirestore.class, FirebaseStorage.class })
-    @Before
-    public void setUp() {
-        PowerMockito.mockStatic(FirebaseFirestore.class);
-        PowerMockito.mockStatic(FirebaseStorage.class);
-
-        FirebaseFirestore mockFirestore = Mockito.mock(FirebaseFirestore.class);
-        FirebaseStorage mockStorage = Mockito.mock(FirebaseStorage.class);
-
-        Mockito.when(FirebaseFirestore.getInstance()).thenReturn(mockFirestore);
-        Mockito.when(FirebaseStorage.getInstance()).thenReturn(mockStorage);
-
-    }
-
-    /**
-     * Tests the generation of a deterministic image to ensure the output is non-null and has the expected dimensions.
-     */
     @Test
-    public void testGenerateDeterministicImage() {
-//        ImageManager imageManager = new ImageManager();
-//        String testInput = "testUser";
-//        Bitmap image = imageManager.generateDeterministicImage(testInput);
-//
-//        assertNotNull(image, "Generated image should not be null");
-//        assertEquals(100, image.getWidth(), "Image width should be 100 pixels");
-//        assertEquals(100, image.getHeight(), "Image height should be 100 pixels");
-        ImageManager imageManager = new ImageManager();
-        String input = "testInput";
+    public void testCreateImageManager() {
+        try(MockedStatic<FirebaseFirestore> mockedFirestore = mockStatic(FirebaseFirestore.class);
+            MockedStatic<FirebaseStorage> mockedStorage = mockStatic(FirebaseStorage.class)) {
+            mockedStorage.when(FirebaseStorage::getInstance).thenReturn(mockStorage);
+            mockedFirestore.when(FirebaseFirestore::getInstance).thenReturn(mockDb);
+            when(mockStorage.getReference()).thenReturn(mockStorageRef);
+            when(mockStorageRef.child(anyString())).thenReturn(mockImageRef);
+            when(mockImageRef.putFile(any(Uri.class))).thenReturn(mockUploadTask);
+            when(mockUploadTask.addOnSuccessListener(any())).thenReturn(mockUploadTask);
 
-        // Generate an image with a specific input
-        Bitmap firstImage = imageManager.generateDeterministicImage(input);
-        assertNotNull(firstImage, "The generated image should not be null.");
+            ImageManager imageManager = new ImageManager();
 
-        // Generate another image with the same input
-        Bitmap secondImage = imageManager.generateDeterministicImage(input);
-        assertNotNull(secondImage, "The generated image should not be null.");
+            imageManager.uploadImage(mockContext, mock(Uri.class), "userId", "/Image/path", new ImageManager.UploadCallback() {
+                @Override
+                public void onSuccess(String imageUrl) { }
+                @Override
+                public void onFailure(Exception exception) { }
+            });
 
-        // Convert Bitmaps to byte arrays for comparison
-        byte[] firstImageBytes = ImageManager.bitmapToByteArray(firstImage);
-        byte[] secondImageBytes = ImageManager.bitmapToByteArray(secondImage);
-
-        // Check if two generated images from the same input are identical
-        assertArrayEquals(firstImageBytes, secondImageBytes, "The images should be identical when generated with the same input.");
-
-        // Optionally, verify that different inputs produce different images
-        String differentInput = "differentTestInput";
-        Bitmap differentImage = imageManager.generateDeterministicImage(differentInput);
-        byte[] differentImageBytes = ImageManager.bitmapToByteArray(differentImage);
-
-        assertFalse(Arrays.equals(firstImageBytes, differentImageBytes), "The images should be different when generated with different inputs.");
-    }
-
-    /**
-     * Tests the upload image functionality by simulating an upload to Firebase Storage and verifying the interaction.
-     * This test ensures that the method correctly uploads a file to the specified path in Firebase Storage.
-     */
-    @Test
-    public void testUploadImage() {
-        Uri fileUri = mock(Uri.class);//Uri.parse("android.resource://com.example.eventlinkqr/drawable/ic_launcher_foreground");
-        String userId = "testUser";
-        String imagePath = "images/testImage.jpg";
-
-        // Setup the mock to simulate a successful upload
-        when(mockUploadTask.isSuccessful()).thenReturn(true);
-        when(mockUploadTask.addOnSuccessListener(any())).thenAnswer(invocation -> {
-            OnSuccessListener<UploadTask.TaskSnapshot> listener = invocation.getArgument(0);
-            UploadTask.TaskSnapshot snapshot = mock(UploadTask.TaskSnapshot.class);
-            listener.onSuccess(snapshot);
-            return mockUploadTask;
-        });
-
-        imageManager = new ImageManager();
-
-//        imageManager.uploadImage(context, fileUri, userId, imagePath, );
-
-        verify(mockStorageRef).putFile(fileUri);
-
-        // verify that your Firestore database is updated correctly, depending on how onSuccessListener of the upload task is setup.
-        verify(mockDocumentRef).update("imagePath", imagePath);
+            verify(mockImageRef, times(1)).putFile(any(Uri.class));
+            verify(mockUploadTask, times(1)).addOnSuccessListener(any());
+            verify(mockUploadTask, times(1)).addOnFailureListener(any());
+        }
     }
 }

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeManagerTest.java
@@ -2,6 +2,7 @@ package com.example.eventlinkqr;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,6 +58,9 @@ public class QRCodeManagerTest {
             int codeType = 1;
             String eventId = "eventId";
 
+            DocumentReference mockEventReference = mock(DocumentReference.class);
+            when(mockFirestore.document("/Events/eventId")).thenReturn(mockEventReference);
+
             // Act
             Task<Void> result = QRCodeManager.addQRCode(codeText, codeType, eventId);
 
@@ -66,7 +70,7 @@ public class QRCodeManagerTest {
             verify(mockDocumentReference).set(argumentCaptor.capture());
             Map<String, Object> capturedArgument = argumentCaptor.getValue();
             Assertions.assertEquals(codeType, capturedArgument.get("codeType"));
-            Assertions.assertEquals("/Events/" + eventId, capturedArgument.get("event"));
+            Assertions.assertEquals(mockEventReference, capturedArgument.get("event"));
         }
     }
 

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeManagerTest.java
@@ -1,0 +1,94 @@
+package com.example.eventlinkqr;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+public class QRCodeManagerTest {
+    @Mock
+    public CollectionReference mockCollectionReference;
+
+    @Mock
+    public DocumentReference mockDocumentReference;
+
+    @Mock
+    public DatabaseManager mockDb;
+
+    @Mock
+    public FirebaseFirestore mockFirestore;
+
+    @BeforeEach
+    void setUp() {
+        when(mockDb.getFirebaseFirestore()).thenReturn(mockFirestore);
+        when(mockFirestore.collection("QRCode")).thenReturn(mockCollectionReference);
+        when(mockCollectionReference.document(anyString())).thenReturn(mockDocumentReference);
+    }
+
+    @Test
+    void addQRCodeTest() {
+        // Note, this test was adapted from Chat GPTs suggestion, still citing it here.
+        // OpenAI, 2024, ChatGPT, Test add QR code
+        try (MockedStatic<DatabaseManager> mockedDbManager = mockStatic(DatabaseManager.class)) {
+            mockedDbManager.when(DatabaseManager::getInstance).thenReturn(mockDb);
+            when(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null));
+
+            // Arrange
+            String codeText = "sampleCode";
+            int codeType = 1;
+            Event event = new Event("eventId", "event description", "category", Timestamp.now(), "location", true);
+
+            // Act
+            Task<Void> result = QRCodeManager.addQRCode(codeText, codeType, event);
+
+            // Assert
+            Assertions.assertTrue(result.isSuccessful());
+            ArgumentCaptor<Map<String, Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+            verify(mockDocumentReference).set(argumentCaptor.capture());
+            Map<String, Object> capturedArgument = argumentCaptor.getValue();
+            Assertions.assertEquals(codeType, capturedArgument.get("codeType"));
+            Assertions.assertEquals("/Event/" + event.getId(), capturedArgument.get("event"));
+        }
+    }
+
+    @Test
+    public void addQrCodeFailed() {
+        // Note, this test was adapted from Chat GPTs suggestion, still citing it here.
+        // OpenAI, 2024, ChatGPT, Test add QR code
+        try (MockedStatic<DatabaseManager> mockedDbManager = mockStatic(DatabaseManager.class)) {
+            mockedDbManager.when(DatabaseManager::getInstance).thenReturn(mockDb);
+            when(mockDocumentReference.set(any())).thenReturn(Tasks.forException(new Exception()));
+
+            // Arrange
+            String codeText = "sampleCode";
+            int codeType = 1;
+            Event event = new Event("eventId", "event description", "category", Timestamp.now(), "location", true);
+
+            // Act
+            Task<Void> result = QRCodeManager.addQRCode(codeText, codeType, event);
+
+            // Assert
+            Assertions.assertFalse(result.isSuccessful());
+        }
+    }
+}

--- a/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeManagerTest.java
+++ b/code/EventLinkQR/app/src/test/java/com/example/eventlinkqr/QRCodeManagerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
-import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -56,10 +55,10 @@ public class QRCodeManagerTest {
             // Arrange
             String codeText = "sampleCode";
             int codeType = 1;
-            Event event = new Event("eventId", "event description", "category", Timestamp.now(), "location", true);
+            String eventId = "eventId";
 
             // Act
-            Task<Void> result = QRCodeManager.addQRCode(codeText, codeType, event);
+            Task<Void> result = QRCodeManager.addQRCode(codeText, codeType, eventId);
 
             // Assert
             Assertions.assertTrue(result.isSuccessful());
@@ -67,7 +66,7 @@ public class QRCodeManagerTest {
             verify(mockDocumentReference).set(argumentCaptor.capture());
             Map<String, Object> capturedArgument = argumentCaptor.getValue();
             Assertions.assertEquals(codeType, capturedArgument.get("codeType"));
-            Assertions.assertEquals("/Event/" + event.getId(), capturedArgument.get("event"));
+            Assertions.assertEquals("/Events/" + eventId, capturedArgument.get("event"));
         }
     }
 
@@ -82,10 +81,11 @@ public class QRCodeManagerTest {
             // Arrange
             String codeText = "sampleCode";
             int codeType = 1;
-            Event event = new Event("eventId", "event description", "category", Timestamp.now(), "location", true);
+
+            String eventId = "eventId";
 
             // Act
-            Task<Void> result = QRCodeManager.addQRCode(codeText, codeType, event);
+            Task<Void> result = QRCodeManager.addQRCode(codeText, codeType, eventId);
 
             // Assert
             Assertions.assertFalse(result.isSuccessful());


### PR DESCRIPTION
A somewhat big PR that ties together some key components of our app. 

- Creating an event now also creates a corresponding QR Code
- Event QR codes can now be viewed by selecting an event as an organizer.
- Upon creating an event, as custom code can be scanned in and used in place of an auto generated one.
- Scanning such a code as an attendee will check you into the event.