### PR TITLE
User Permission for Notifications

### DIFF
--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
@@ -62,6 +62,11 @@ public class AttendeeMainActivity extends Activity {
             startActivity(intent);
         });
 
+
+         // Handles the click event on the notification button. For devices running Android 13 (API level 33) or higher,
+         // checks if notification permission is granted. If permission is granted, navigates to the NotificationDisplayActivity.
+         // If not, shows a custom dialog to guide users to enable notifications. For devices below Android 13, directly
+         // navigates to the NotificationDisplayActivity as permission checks are not required.
         notificationButton.setOnClickListener(view -> {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 if (ContextCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS) ==

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
@@ -1,13 +1,22 @@
 package com.example.eventlinkqr;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ListView;
+import android.widget.Toast;
+
+import androidx.core.content.ContextCompat;
+
 import com.google.android.material.button.MaterialButton;
 
 /**
@@ -58,11 +67,55 @@ public class AttendeeMainActivity extends Activity {
             startActivity(intent);
         });
 
+//        notificationButton.setOnClickListener(view -> {
+//            // Create an intent to start NotificationActivity
+//            Intent intent = new Intent(AttendeeMainActivity.this, NotificationDisplayActivity.class);
+//            startActivity(intent);
+//        });
+
         notificationButton.setOnClickListener(view -> {
-            // Create an intent to start NotificationActivity
-            Intent intent = new Intent(AttendeeMainActivity.this, NotificationDisplayActivity.class);
-            startActivity(intent);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                if (ContextCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS) ==
+                        PackageManager.PERMISSION_GRANTED) {
+                    // Permission granted, proceed with showing notifications
+                    Intent intent = new Intent(this, NotificationDisplayActivity.class);
+                    startActivity(intent);
+                } else {
+                    // Permission denied, guide user to settings or show educational UI
+                    showCustomPermissionDialog();
+                }
+            } else {
+                // For Android versions below Tiramisu, permission model is different and direct system settings guidance may be needed if notifications are turned off
+                Intent intent = new Intent(this, NotificationDisplayActivity.class);
+                startActivity(intent);
+            }
         });
 
     }
+
+    private void showCustomPermissionDialog() {
+        new AlertDialog.Builder(this)
+                .setTitle("Enable Notifications")
+                .setMessage("Notifications help you stay up to date with important events. Would you like to enable notifications for our app?")
+                .setPositiveButton("Yes", (dialog, which) -> {
+                    // Direct users to the app's system settings page
+                    Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                    Uri uri = Uri.fromParts("package", getPackageName(), null);
+                    intent.setData(uri);
+                    startActivity(intent);
+                    // Proceed to NotificationDisplayActivity after showing settings
+                    navigateToNotificationDisplayActivity();
+                })
+                .setNegativeButton("No", (dialog, which) -> {
+                    // User chose not to enable notifications, proceed to NotificationDisplayActivity anyway
+                    navigateToNotificationDisplayActivity();
+                })
+                .create().show();
+    }
+
+    private void navigateToNotificationDisplayActivity() {
+        Intent intent = new Intent(this, NotificationDisplayActivity.class);
+        startActivity(intent);
+    }
+
 }

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
@@ -9,12 +9,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
-import android.util.Log;
-import android.view.View;
-import android.widget.Button;
 import android.widget.ListView;
-import android.widget.Toast;
-
 import androidx.core.content.ContextCompat;
 
 import com.google.android.material.button.MaterialButton;
@@ -75,7 +70,7 @@ public class AttendeeMainActivity extends Activity {
                     Intent intent = new Intent(this, NotificationDisplayActivity.class);
                     startActivity(intent);
                 } else {
-                    // Permission denied, guide user to settings or show educational UI
+                    // Permission denied, guide user to settings
                     showCustomPermissionDialog();
                 }
             } else {
@@ -87,25 +82,14 @@ public class AttendeeMainActivity extends Activity {
 
     }
 
-//    private void showCustomPermissionDialog() {
-//        new AlertDialog.Builder(this)
-//                .setTitle("Enable Notifications")
-//                .setMessage("Notifications help you stay up to date with important events. Would you like to enable notifications for our app?")
-//                .setPositiveButton("Yes", (dialog, which) -> {
-//                    // Direct users to the app's system settings page
-//                    Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-//                    Uri uri = Uri.fromParts("package", getPackageName(), null);
-//                    intent.setData(uri);
-//                    startActivity(intent);
-//                })
-//                .setNegativeButton("No", (dialog, which) -> {
-//                    // User chose not to enable notifications, proceed to NotificationDisplayActivity anyway
-//                    Intent intent = new Intent(this, NotificationDisplayActivity.class);
-//                    startActivity(intent);
-//                })
-//                .create().show();
-//    }
-
+    /**
+     * Displays a custom dialog to request notification permission from the user.
+     * This method first checks if the user has already been prompted for notification permission.
+     * If not, it presents an AlertDialog asking the user if they wish to enable notifications for the app.
+     * A positive response directs the user to the app's system settings to enable notifications,
+     * while a negative response simply proceeds to the NotificationDisplayActivity.
+     * Regardless of the user's choice, their decision is recorded to avoid repeated prompts.
+     */
     private void showCustomPermissionDialog() {
         if (!shouldPromptForNotificationPermission()) {
             // User has already been prompted, proceed directly to NotificationDisplayActivity
@@ -142,7 +126,12 @@ public class AttendeeMainActivity extends Activity {
                 .create().show();
     }
 
-
+    /**
+     * Checks whether the app should prompt the user for notification permission. This is based on
+     * whether the user has previously been prompted.
+     *
+     * @return True if the user has not been prompted before, false otherwise.
+     */
     private boolean shouldPromptForNotificationPermission() {
         SharedPreferences prefs = getSharedPreferences("NotificationPrefs", MODE_PRIVATE);
         return !prefs.contains("hasBeenPromptedForNotificationPermission");

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
@@ -67,12 +67,6 @@ public class AttendeeMainActivity extends Activity {
             startActivity(intent);
         });
 
-//        notificationButton.setOnClickListener(view -> {
-//            // Create an intent to start NotificationActivity
-//            Intent intent = new Intent(AttendeeMainActivity.this, NotificationDisplayActivity.class);
-//            startActivity(intent);
-//        });
-
         notificationButton.setOnClickListener(view -> {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 if (ContextCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS) ==
@@ -93,29 +87,65 @@ public class AttendeeMainActivity extends Activity {
 
     }
 
+//    private void showCustomPermissionDialog() {
+//        new AlertDialog.Builder(this)
+//                .setTitle("Enable Notifications")
+//                .setMessage("Notifications help you stay up to date with important events. Would you like to enable notifications for our app?")
+//                .setPositiveButton("Yes", (dialog, which) -> {
+//                    // Direct users to the app's system settings page
+//                    Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+//                    Uri uri = Uri.fromParts("package", getPackageName(), null);
+//                    intent.setData(uri);
+//                    startActivity(intent);
+//                })
+//                .setNegativeButton("No", (dialog, which) -> {
+//                    // User chose not to enable notifications, proceed to NotificationDisplayActivity anyway
+//                    Intent intent = new Intent(this, NotificationDisplayActivity.class);
+//                    startActivity(intent);
+//                })
+//                .create().show();
+//    }
+
     private void showCustomPermissionDialog() {
+        if (!shouldPromptForNotificationPermission()) {
+            // User has already been prompted, proceed directly to NotificationDisplayActivity
+            Intent intent = new Intent(this, NotificationDisplayActivity.class);
+            startActivity(intent);
+            return;
+        }
+
         new AlertDialog.Builder(this)
                 .setTitle("Enable Notifications")
                 .setMessage("Notifications help you stay up to date with important events. Would you like to enable notifications for our app?")
                 .setPositiveButton("Yes", (dialog, which) -> {
+                    // Record that the user has been prompted
+                    SharedPreferences.Editor editor = getSharedPreferences("NotificationPrefs", MODE_PRIVATE).edit();
+                    editor.putBoolean("hasBeenPromptedForNotificationPermission", true);
+                    editor.apply();
+
                     // Direct users to the app's system settings page
                     Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
                     Uri uri = Uri.fromParts("package", getPackageName(), null);
                     intent.setData(uri);
                     startActivity(intent);
-                    // Proceed to NotificationDisplayActivity after showing settings
-                    navigateToNotificationDisplayActivity();
                 })
                 .setNegativeButton("No", (dialog, which) -> {
-                    // User chose not to enable notifications, proceed to NotificationDisplayActivity anyway
-                    navigateToNotificationDisplayActivity();
+                    // Record that the user has been prompted
+                    SharedPreferences.Editor editor = getSharedPreferences("NotificationPrefs", MODE_PRIVATE).edit();
+                    editor.putBoolean("hasBeenPromptedForNotificationPermission", true);
+                    editor.apply();
+
+                    // User chose not to enable notifications, proceed to NotificationDisplayActivity
+                    Intent intent = new Intent(this, NotificationDisplayActivity.class);
+                    startActivity(intent);
                 })
                 .create().show();
     }
 
-    private void navigateToNotificationDisplayActivity() {
-        Intent intent = new Intent(this, NotificationDisplayActivity.class);
-        startActivity(intent);
+
+    private boolean shouldPromptForNotificationPermission() {
+        SharedPreferences prefs = getSharedPreferences("NotificationPrefs", MODE_PRIVATE);
+        return !prefs.contains("hasBeenPromptedForNotificationPermission");
     }
 
 }

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeProfileActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeProfileActivity.java
@@ -147,6 +147,12 @@ public class AttendeeProfileActivity extends AppCompatActivity {
         editor.remove("UUID"); // Clear only the UUID
         editor.apply();
 
+        // Also clear NotificationPrefs shared preferences
+        SharedPreferences notificationPrefs = getSharedPreferences("NotificationPrefs", MODE_PRIVATE);
+        SharedPreferences.Editor notificationEditor = notificationPrefs.edit();
+        notificationEditor.clear(); // Clear all preferences related to notification
+        notificationEditor.apply();
+
         // Redirect to LandingPage
         Intent intent = new Intent(this, LandingPage.class);
         startActivity(intent);

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/LandingPage.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/LandingPage.java
@@ -1,3 +1,77 @@
+//package com.example.eventlinkqr;
+//
+//import static android.content.ContentValues.TAG;
+//
+//import android.app.NotificationChannel;
+//import android.app.NotificationManager;
+//import android.content.Intent;
+//import android.content.SharedPreferences;
+//import android.os.Build;
+//import android.os.Bundle;
+//import android.util.Log;
+//import android.view.View;
+//import android.widget.Button;
+//import androidx.appcompat.app.AppCompatActivity;
+//
+//import com.google.firebase.messaging.FirebaseMessaging;
+//
+//public class LandingPage extends AppCompatActivity {
+//
+//    @Override
+//    protected void onCreate(Bundle savedInstanceState) {
+//        super.onCreate(savedInstanceState);
+//        setContentView(R.layout.activity_landing_page);
+//
+//        SharedPreferences prefs = getSharedPreferences("MyAppPrefs", MODE_PRIVATE);
+//        String uuid = prefs.getString("UUID", null);
+//
+//        Button createProfileButton = findViewById(R.id.createProfile);
+//
+//        if (uuid == null) {
+//            createProfileButton.setOnClickListener(new View.OnClickListener() {
+//                @Override
+//                public void onClick(View v) {
+//                    // User needs to create a profile
+//                    Intent intent = new Intent(LandingPage.this, AttendeeProfileActivity.class);
+//                    startActivity(intent);
+//                }
+//            });
+//        } else {
+//            // UUID exists, go directly to AttendeeMainActivity
+//            Intent intent = new Intent(LandingPage.this, AttendeeMainActivity.class);
+//            startActivity(intent);
+//            finish(); // Close the landing page activity
+//        }
+//
+//        FirebaseMessaging.getInstance().getToken()
+//                .addOnCompleteListener(task -> {
+//                    if (!task.isSuccessful()) {
+//                        Log.w(TAG, "Fetching FCM registration token failed", task.getException());
+//                        return;
+//                    }
+//                    // Get new FCM registration token
+//                    String token = task.getResult();
+//                    // Log and toast
+//                    Log.d(TAG, "FCM Token: " + token);
+//                });
+//
+//        // Check for Android Oreo (API 26) or newer to create a notification channel as it is mandatory for notifications on these versions.
+//        // For older versions, no channel is required.
+//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+//            CharSequence name = getString(R.string.channel_name);
+//            String description = getString(R.string.channel_description);
+//            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+//            NotificationChannel channel = new NotificationChannel("event_notifications", name, importance);
+//            channel.setDescription(description);
+//            // Register the channel with the system
+//            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+//            notificationManager.createNotificationChannel(channel);
+//            Log.d("NotificationChannel", "Channel created");
+//        }
+//
+//    }
+//}
+
 package com.example.eventlinkqr;
 
 import static android.content.ContentValues.TAG;
@@ -6,68 +80,109 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 
 public class LandingPage extends AppCompatActivity {
+
+    private ActivityResultLauncher<String> requestPermissionLauncher;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_landing_page);
 
+        initializeNotificationChannel();
+        handleCreateProfileButton();
+
+        requestPermissionLauncher =
+                registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
+                    if (isGranted) {
+                        Log.d(TAG, "Notification permission granted");
+                        // Permission is granted. Continue the action or workflow in your app.
+                    } else {
+                        Log.d(TAG, "Notification permission denied");
+                        // Explain to the user that the feature is unavailable because the
+                        // features requires a permission that the user has denied. At the
+                        // same time, respect the user's decision. Don't link to system
+                        // settings in an effort to convince the user to change their decision.
+                    }
+                });
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            requestNotificationPermission();
+        }
+    }
+
+    private void handleCreateProfileButton() {
         SharedPreferences prefs = getSharedPreferences("MyAppPrefs", MODE_PRIVATE);
         String uuid = prefs.getString("UUID", null);
 
         Button createProfileButton = findViewById(R.id.createProfile);
 
         if (uuid == null) {
-            createProfileButton.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    // User needs to create a profile
-                    Intent intent = new Intent(LandingPage.this, AttendeeProfileActivity.class);
-                    startActivity(intent);
-                }
+            createProfileButton.setOnClickListener(v -> {
+                Intent intent = new Intent(LandingPage.this, AttendeeProfileActivity.class);
+                startActivity(intent);
             });
         } else {
-            // UUID exists, go directly to AttendeeMainActivity
             Intent intent = new Intent(LandingPage.this, AttendeeMainActivity.class);
             startActivity(intent);
-            finish(); // Close the landing page activity
+            finish();
         }
+    }
 
+    private void initializeNotificationChannel() {
         FirebaseMessaging.getInstance().getToken()
                 .addOnCompleteListener(task -> {
                     if (!task.isSuccessful()) {
                         Log.w(TAG, "Fetching FCM registration token failed", task.getException());
                         return;
                     }
-                    // Get new FCM registration token
                     String token = task.getResult();
-                    // Log and toast
                     Log.d(TAG, "FCM Token: " + token);
                 });
 
-        // Check for Android Oreo (API 26) or newer to create a notification channel as it is mandatory for notifications on these versions. 
-        // For older versions, no channel is required.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             CharSequence name = getString(R.string.channel_name);
             String description = getString(R.string.channel_description);
             int importance = NotificationManager.IMPORTANCE_DEFAULT;
             NotificationChannel channel = new NotificationChannel("event_notifications", name, importance);
             channel.setDescription(description);
-            // Register the channel with the system
             NotificationManager notificationManager = getSystemService(NotificationManager.class);
-            notificationManager.createNotificationChannel(channel);
-            Log.d("NotificationChannel", "Channel created");
+            if (notificationManager != null) {
+                notificationManager.createNotificationChannel(channel);
+            }
         }
+    }
 
+    private void requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS) ==
+                    PackageManager.PERMISSION_GRANTED) {
+                // You can use the API that requires the permission.
+            } else if (shouldShowRequestPermissionRationale(android.Manifest.permission.POST_NOTIFICATIONS)) {
+                // In an educational UI, explain to the user why your app requires this
+                // permission for a specific feature to behave as expected. In this UI,
+                // include a "cancel" or "no thanks" button that allows the user to
+                // continue using your app without granting the permission.
+                requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS);
+            } else {
+                // You can directly ask for the permission.
+                // The registered ActivityResultCallback gets the result of this request.
+                requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS);
+            }
+        }
     }
 }
+

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/LandingPage.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/LandingPage.java
@@ -1,77 +1,3 @@
-//package com.example.eventlinkqr;
-//
-//import static android.content.ContentValues.TAG;
-//
-//import android.app.NotificationChannel;
-//import android.app.NotificationManager;
-//import android.content.Intent;
-//import android.content.SharedPreferences;
-//import android.os.Build;
-//import android.os.Bundle;
-//import android.util.Log;
-//import android.view.View;
-//import android.widget.Button;
-//import androidx.appcompat.app.AppCompatActivity;
-//
-//import com.google.firebase.messaging.FirebaseMessaging;
-//
-//public class LandingPage extends AppCompatActivity {
-//
-//    @Override
-//    protected void onCreate(Bundle savedInstanceState) {
-//        super.onCreate(savedInstanceState);
-//        setContentView(R.layout.activity_landing_page);
-//
-//        SharedPreferences prefs = getSharedPreferences("MyAppPrefs", MODE_PRIVATE);
-//        String uuid = prefs.getString("UUID", null);
-//
-//        Button createProfileButton = findViewById(R.id.createProfile);
-//
-//        if (uuid == null) {
-//            createProfileButton.setOnClickListener(new View.OnClickListener() {
-//                @Override
-//                public void onClick(View v) {
-//                    // User needs to create a profile
-//                    Intent intent = new Intent(LandingPage.this, AttendeeProfileActivity.class);
-//                    startActivity(intent);
-//                }
-//            });
-//        } else {
-//            // UUID exists, go directly to AttendeeMainActivity
-//            Intent intent = new Intent(LandingPage.this, AttendeeMainActivity.class);
-//            startActivity(intent);
-//            finish(); // Close the landing page activity
-//        }
-//
-//        FirebaseMessaging.getInstance().getToken()
-//                .addOnCompleteListener(task -> {
-//                    if (!task.isSuccessful()) {
-//                        Log.w(TAG, "Fetching FCM registration token failed", task.getException());
-//                        return;
-//                    }
-//                    // Get new FCM registration token
-//                    String token = task.getResult();
-//                    // Log and toast
-//                    Log.d(TAG, "FCM Token: " + token);
-//                });
-//
-//        // Check for Android Oreo (API 26) or newer to create a notification channel as it is mandatory for notifications on these versions.
-//        // For older versions, no channel is required.
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-//            CharSequence name = getString(R.string.channel_name);
-//            String description = getString(R.string.channel_description);
-//            int importance = NotificationManager.IMPORTANCE_DEFAULT;
-//            NotificationChannel channel = new NotificationChannel("event_notifications", name, importance);
-//            channel.setDescription(description);
-//            // Register the channel with the system
-//            NotificationManager notificationManager = getSystemService(NotificationManager.class);
-//            notificationManager.createNotificationChannel(channel);
-//            Log.d("NotificationChannel", "Channel created");
-//        }
-//
-//    }
-//}
-
 package com.example.eventlinkqr;
 
 import static android.content.ContentValues.TAG;
@@ -93,6 +19,10 @@ import androidx.core.content.ContextCompat;
 
 import com.google.firebase.messaging.FirebaseMessaging;
 
+/**
+ * The LandingPage activity serves as the entry point to the attendee section.
+ * It also handles the creation of notification channels and requesting notification permissions on Android Tiramisu (13) and above.
+ */
 public class LandingPage extends AppCompatActivity {
 
     private ActivityResultLauncher<String> requestPermissionLauncher;
@@ -105,25 +35,26 @@ public class LandingPage extends AppCompatActivity {
         initializeNotificationChannel();
         handleCreateProfileButton();
 
+        // Initialize the permission request launcher
         requestPermissionLauncher =
                 registerForActivityResult(new ActivityResultContracts.RequestPermission(), isGranted -> {
                     if (isGranted) {
                         Log.d(TAG, "Notification permission granted");
-                        // Permission is granted. Continue the action or workflow in your app.
                     } else {
                         Log.d(TAG, "Notification permission denied");
-                        // Explain to the user that the feature is unavailable because the
-                        // features requires a permission that the user has denied. At the
-                        // same time, respect the user's decision. Don't link to system
-                        // settings in an effort to convince the user to change their decision.
                     }
                 });
 
+        // Request notification permission for Android Tiramisu and above
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             requestNotificationPermission();
         }
     }
 
+    /**
+     * Handles the logic for the Create Profile button,
+     * directing users to the profile creation page if no UUID is found, or to the main activity if it exists.
+     */
     private void handleCreateProfileButton() {
         SharedPreferences prefs = getSharedPreferences("MyAppPrefs", MODE_PRIVATE);
         String uuid = prefs.getString("UUID", null);
@@ -142,6 +73,10 @@ public class LandingPage extends AppCompatActivity {
         }
     }
 
+    /**
+     * Initializes the notification channel for the app,
+     * which is required for app notifications on Android Oreo and above.
+     */
     private void initializeNotificationChannel() {
         FirebaseMessaging.getInstance().getToken()
                 .addOnCompleteListener(task -> {
@@ -153,6 +88,8 @@ public class LandingPage extends AppCompatActivity {
                     Log.d(TAG, "FCM Token: " + token);
                 });
 
+        // Check for Android Oreo (API 26) or newer to create a notification channel as it is mandatory for notifications on these versions.
+        // For older versions, no channel is required.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             CharSequence name = getString(R.string.channel_name);
             String description = getString(R.string.channel_description);
@@ -166,20 +103,18 @@ public class LandingPage extends AppCompatActivity {
         }
     }
 
+    /**
+     * Requests notification permission for Android Tiramisu (API level 33) and above. For these versions,
+     * the app must ask for POST_NOTIFICATIONS permission to display notifications. This method checks for
+     * permission and requests it if not already granted. For versions below Tiramisu, this permission is not
+     * required, and the method does not perform any action, ensuring backward compatibility.
+     */
     private void requestNotificationPermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (ContextCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS) ==
                     PackageManager.PERMISSION_GRANTED) {
-                // You can use the API that requires the permission.
-            } else if (shouldShowRequestPermissionRationale(android.Manifest.permission.POST_NOTIFICATIONS)) {
-                // In an educational UI, explain to the user why your app requires this
-                // permission for a specific feature to behave as expected. In this UI,
-                // include a "cancel" or "no thanks" button that allows the user to
-                // continue using your app without granting the permission.
-                requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS);
+                // Permission is already granted
             } else {
-                // You can directly ask for the permission.
-                // The registered ActivityResultCallback gets the result of this request.
                 requestPermissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS);
             }
         }

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/NotificationDisplayActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/NotificationDisplayActivity.java
@@ -118,12 +118,7 @@ public class NotificationDisplayActivity extends AppCompatActivity {
             Intent intent = new Intent(NotificationDisplayActivity.this, NotificationDisplayActivity.class);
             startActivity(intent);
         });
-
-
     }
-
-
-
 
     /**
      * Fetches notifications from the Firebase Firestore database based on the current FCM token.

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/NotificationDisplayActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/NotificationDisplayActivity.java
@@ -3,11 +3,18 @@ package com.example.eventlinkqr;
 import static android.content.ContentValues.TAG;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
+import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import com.google.android.material.button.MaterialButton;
 import com.google.firebase.Timestamp;
@@ -111,7 +118,12 @@ public class NotificationDisplayActivity extends AppCompatActivity {
             Intent intent = new Intent(NotificationDisplayActivity.this, NotificationDisplayActivity.class);
             startActivity(intent);
         });
+
+
     }
+
+
+
 
     /**
      * Fetches notifications from the Firebase Firestore database based on the current FCM token.


### PR DESCRIPTION
It's a short PR adding the below mentioned functionalities  -:

1) Implemented notification permission request for users on Android 13 and above when the app is first launched. (Image 1)
2) Added a custom dialog to prompt users for notification permission again when they attempt to view notifications, if previously denied. (Image 2)

![image](https://github.com/CMPUT301W24T18/EventLinkQR/assets/110370121/38fe6ab5-aa63-4b95-b082-b452a955153e)
![Screenshot_20240308_000257](https://github.com/CMPUT301W24T18/EventLinkQR/assets/110370121/d6efac24-2e72-4c14-9220-91a11ff9fd1f)
