### PR TITLE
Fix bug with navigating to event details via promotional QR

### DIFF
--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/AttendeeMainActivity.java
@@ -157,7 +157,7 @@ public class AttendeeMainActivity extends AppCompatActivity {
                         // This is a promotional code, redirect to the attendee event details page
                         EventManager.getEventById(code.getEventId(), event -> {
                             setCurrentEvent(event);
-                            Navigation.findNavController(navController).navigate(R.id.action_attendeeHomePage_to_attendeeEventFragment);
+                            Navigation.findNavController(navController).navigate(R.id.attendeeEventFragment);
                         });
                     }
                 });

--- a/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/UploadImageActivity.java
+++ b/code/EventLinkQR/app/src/main/java/com/example/eventlinkqr/UploadImageActivity.java
@@ -48,7 +48,7 @@ public class UploadImageActivity extends AppCompatActivity {
             });
 
     @Override
-    public void  onCreate(Bundle savedInstanceState) {
+    public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.fragment_image_upload);
 


### PR DESCRIPTION
Before this only worked if you were navigating from the home page, now you can initiate the scan from anywhere in the app that shows the "scan" button and it will actually take you to the event details page.